### PR TITLE
[Fixes #138] Adds volumes to docker-compose for live reloading

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build: .
     environment:
       FLASK_ENV: "docker_dev"
+    volumes:
+      - .:/usr/src/app
     ports:
       - "5000:5000"
     links:


### PR DESCRIPTION
By adding the working directory as a volume to docker-compose,
we're able to take advantage of manage.py and trigger a reload
anytime the file changes on the host system
(and as a result in the Docker container)