### PR TITLE
Fix force next speaker from options

### DIFF
--- a/kcards/views/api_rooms.py
+++ b/kcards/views/api_rooms.py
@@ -135,7 +135,7 @@ def next_speaker(code, name=None, force=False):
     if not room.queue:
         return get_content(room), status.HTTP_200_OK
 
-    if room.queue[0]['name'] == name or force:
+    if room.queue[0]['name'] == name or request.data['force']:
         room.next_speaker()
 
     room.save()


### PR DESCRIPTION
- Using the API only, sending force to /next would not update the speaker correctly
- The force data is now pulled from the request, and the api works.